### PR TITLE
feat: [004-SIGNUP] 회원가입, 이메일 확인 기능 구현 머지 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    // SpringSecurity for Auth
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // JWT for Auth
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 
     // Openfeign for Email
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     // JWT for Auth
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+    // ApacheCommons for Auth
+    implementation 'org.apache.commons:commons-lang3:3.13.0'
 
     // Openfeign for Email
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // SpringSecurity for Auth
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     // JWT for Auth
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     // ApacheCommons for Auth

--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.valuewith.tweaver.auth.controller;
 
-import com.valuewith.tweaver.auth.dto.AuthDto;
+import com.valuewith.tweaver.auth.dto.AuthDto.*;
 import com.valuewith.tweaver.auth.service.AuthService;
 import com.valuewith.tweaver.user.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,7 +21,17 @@ public class AuthController {
   // TODO: 회원가입(등록), 이메일 인증
 
   @PostMapping("/signup")
-  public ResponseEntity<Member> signUp(@RequestBody AuthDto.SignUpForm request) {
-    return ResponseEntity.ok(authService.signUp(request));
+  public ResponseEntity<Member> signUp(@RequestBody SignUpForm request, MultipartFile file) {
+    return ResponseEntity.ok(authService.signUp(request, file));
+  }
+
+  @PostMapping("/verify")
+  public void sendCode(@RequestBody EmailInput request) {
+    authService.sendEmailVerification(request);
+  }
+
+  @PostMapping("/verify/check")
+  public ResponseEntity<Boolean> checkCode(@RequestBody VerificationForm request) {
+    return ResponseEntity.ok(authService.isVerified(request));  // true
   }
 }

--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -1,0 +1,26 @@
+package com.valuewith.tweaver.auth.controller;
+
+import com.valuewith.tweaver.auth.dto.AuthDto;
+import com.valuewith.tweaver.auth.service.AuthService;
+import com.valuewith.tweaver.user.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  // TODO: 회원가입(등록), 이메일 인증
+
+  @PostMapping("/signup")
+  public ResponseEntity<Member> signUp(@RequestBody AuthDto.SignUpForm request) {
+    return ResponseEntity.ok(authService.signUp(request));
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -3,11 +3,16 @@ package com.valuewith.tweaver.auth.controller;
 import com.valuewith.tweaver.auth.dto.AuthDto.*;
 import com.valuewith.tweaver.auth.service.AuthService;
 import com.valuewith.tweaver.user.entity.Member;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,8 +25,8 @@ public class AuthController {
 
   // TODO: 회원가입(등록), 이메일 인증
 
-  @PostMapping("/signup")
-  public ResponseEntity<Member> signUp(@RequestBody SignUpForm request, MultipartFile file) {
+  @PostMapping(value = "/signup")
+  public ResponseEntity<Member> signUp(SignUpForm request, MultipartFile file) {
     return ResponseEntity.ok(authService.signUp(request, file));
   }
 

--- a/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
+++ b/src/main/java/com/valuewith/tweaver/auth/controller/AuthController.java
@@ -18,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping(value = "/auth", produces = "application/text; charset=utf8")
 public class AuthController {
 
   private final AuthService authService;
@@ -26,7 +26,7 @@ public class AuthController {
   // TODO: 회원가입(등록), 이메일 인증
 
   @PostMapping(value = "/signup")
-  public ResponseEntity<Member> signUp(SignUpForm request, MultipartFile file) {
+  public ResponseEntity<String> signUp(SignUpForm request, MultipartFile file) {
     return ResponseEntity.ok(authService.signUp(request, file));
   }
 

--- a/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
+++ b/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
@@ -1,11 +1,9 @@
 package com.valuewith.tweaver.auth.dto;
 
 import com.valuewith.tweaver.user.entity.Member;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@Builder
 public class AuthDto {
 
   // TODO: 로그인
@@ -19,16 +17,15 @@ public class AuthDto {
     private String password;
     private String gender;
     private Integer age;
-    private String profileUrl;
 
-    public Member toEntity() {
+    public Member toEntity(String profileUrl) {
       return Member.builder()
           .nickName(this.nickname)
           .email(this.email)
           .password(this.password)
           .gender(this.gender)
           .age(this.age)
-          .profileUrl(this.profileUrl)
+          .profileUrl(profileUrl)
           .isSocial(Boolean.FALSE)
           .build();
     }

--- a/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
+++ b/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
@@ -1,0 +1,37 @@
+package com.valuewith.tweaver.auth.dto;
+
+import com.valuewith.tweaver.user.entity.Member;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+public class AuthDto {
+
+  // TODO:인증, 로그인
+
+  @Data
+  @NoArgsConstructor
+  public static class SignUpForm {
+
+    private String nickname;
+    private String email;
+    private String password;
+    private String gender;
+    private Integer age;
+    private String profileUrl;
+
+    public Member toEntity() {
+      return Member.builder()
+          .nickName(this.nickname)
+          .email(this.email)
+          .password(this.password)
+          .gender(this.gender)
+          .age(this.age)
+          .profileUrl(this.profileUrl)
+          .isSocial(Boolean.FALSE)
+          .build();
+    }
+  }
+
+}

--- a/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
+++ b/src/main/java/com/valuewith/tweaver/auth/dto/AuthDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class AuthDto {
 
-  // TODO:인증, 로그인
+  // TODO: 로그인
 
   @Data
   @NoArgsConstructor
@@ -34,4 +34,16 @@ public class AuthDto {
     }
   }
 
+  @Data
+  @NoArgsConstructor
+  public static class VerificationForm {
+    private String email;
+    private String code;
+  }
+
+  @Data
+  @NoArgsConstructor
+  public static class EmailInput {
+    private String email;
+  }
 }

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -1,0 +1,38 @@
+package com.valuewith.tweaver.auth.service;
+
+import com.valuewith.tweaver.auth.client.mailgun.SendEmailForm;
+import com.valuewith.tweaver.auth.dto.AuthDto;
+import com.valuewith.tweaver.user.entity.Member;
+import com.valuewith.tweaver.user.repository.UserRepository;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final PasswordEncoder passwordEncoder;
+  private final UserRepository userRepository;
+  private final EmailService emailService;
+
+  public boolean isEmailExist(String email) {
+    return userRepository.existsByEmail(email.toLowerCase(Locale.ROOT));
+  }
+
+  public void emailVerification(AuthDto.SignUpForm form) {
+     // TODO: 커스텀 Exception 적용
+    if (isEmailExist(form.getEmail())) {
+      throw new RuntimeException("이미 사용중인 이메일 입니다.");
+    }
+  }
+  public Member signUp(AuthDto.SignUpForm form) {
+
+    // 비밀번호 암호화
+    form.setPassword(this.passwordEncoder.encode(form.getPassword()));
+
+    return userRepository.save(form.toEntity());
+  }
+
+}

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -1,13 +1,16 @@
 package com.valuewith.tweaver.auth.service;
 
-import com.valuewith.tweaver.auth.client.mailgun.SendEmailForm;
 import com.valuewith.tweaver.auth.dto.AuthDto;
+import com.valuewith.tweaver.commons.redis.RedisUtilService;
+import com.valuewith.tweaver.constants.ImageType;
+import com.valuewith.tweaver.defaultImage.service.ImageService;
 import com.valuewith.tweaver.user.entity.Member;
 import com.valuewith.tweaver.user.repository.UserRepository;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -16,18 +19,16 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final UserRepository userRepository;
   private final EmailService emailService;
+  private final RedisUtilService redisUtilService;
+  private final ImageService imageService;
 
-  public boolean isEmailExist(String email) {
-    return userRepository.existsByEmail(email.toLowerCase(Locale.ROOT));
-  }
-
-  public void emailVerification(AuthDto.SignUpForm form) {
-     // TODO: 커스텀 Exception 적용
-    if (isEmailExist(form.getEmail())) {
-      throw new RuntimeException("이미 사용중인 이메일 입니다.");
+  public Member signUp(AuthDto.SignUpForm form, MultipartFile file) {
+    if (file.isEmpty()) {
+      // TODO: 사용자로 부터 사진 등록을 받지 못한 경우 기본 이미지 등록
+      form.setProfileUrl("https://");
     }
-  }
-  public Member signUp(AuthDto.SignUpForm form) {
+    String profileUrl = imageService.uploadImageAndGetUrl(file, ImageType.MEMBER);
+    form.setProfileUrl(profileUrl);
 
     // 비밀번호 암호화
     form.setPassword(this.passwordEncoder.encode(form.getPassword()));
@@ -35,4 +36,30 @@ public class AuthService {
     return userRepository.save(form.toEntity());
   }
 
+  public void sendEmailVerification(AuthDto.EmailInput input) {
+    String receiver = input.getEmail();
+    if (isEmailExist(receiver)) {
+      // TODO: 커스텀 Exception 적용
+      throw new RuntimeException("이미 사용중인 이메일 입니다.");
+    }
+    emailService.sendCodeForValid(receiver);
+  }
+
+  public Boolean isVerified(AuthDto.VerificationForm form) {
+    String emailCode = form.getCode();
+    String savedCode = redisUtilService.getData(form.getEmail());
+    if (savedCode.isEmpty()) {
+      // TODO: 커스텀 Exception 적용
+      throw new RuntimeException("만료된 코드 입니다.");
+    }
+    if (!emailCode.equals(savedCode)) {
+      // TODO: 커스텀 Exception 적용
+      throw new RuntimeException("인증코드가 다릅니다.");
+    }
+    return Boolean.TRUE;
+  }
+
+  public Boolean isEmailExist(String email) {
+    return userRepository.existsByEmail(email.toLowerCase(Locale.ROOT));
+  }
 }

--- a/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/AuthService.java
@@ -24,7 +24,7 @@ public class AuthService {
   private final ImageService imageService;
 
   @Transactional
-  public Member signUp(AuthDto.SignUpForm form, MultipartFile file) {
+  public String signUp(AuthDto.SignUpForm form, MultipartFile file) {
     String profileUrl = "";
     if (file != null && !file.isEmpty()) {
       // 사진을 받아온 경우 이미지 등록
@@ -33,11 +33,10 @@ public class AuthService {
       // TODO: 사진을 받지 못한 경우 기본사진 등록
       profileUrl = "https://";
     }
-
     // 비밀번호 암호화
     form.setPassword(this.passwordEncoder.encode(form.getPassword()));
-
-    return userRepository.save(form.toEntity(profileUrl));
+    userRepository.save(form.toEntity(profileUrl));
+    return "회원가입 완료";
   }
 
   public void sendEmailVerification(AuthDto.EmailInput input) {

--- a/src/main/java/com/valuewith/tweaver/auth/service/EmailService.java
+++ b/src/main/java/com/valuewith/tweaver/auth/service/EmailService.java
@@ -2,7 +2,9 @@ package com.valuewith.tweaver.auth.service;
 
 import com.valuewith.tweaver.auth.client.MailgunClient;
 import com.valuewith.tweaver.auth.client.mailgun.SendEmailForm;
+import com.valuewith.tweaver.commons.redis.RedisUtilService;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,8 +12,33 @@ import org.springframework.stereotype.Service;
 public class EmailService {
 
   private final MailgunClient mailgunClient;
+  private final RedisUtilService redisUtilService;
 
   public String sendMail(SendEmailForm sendForm) {
     return mailgunClient.sendEmail(sendForm).getBody();
+  }
+
+  public void sendCodeForValid(String memberEmail) {
+    String code = createCode();
+    String text = createText(code);
+
+    // 유효시간 설정 (key, value, 유효시간(분))
+    redisUtilService.setDataTimeout(memberEmail, code, 5L);
+    sendMail(SendEmailForm.builder()
+        .to(memberEmail)
+        .from("manager@value.with")
+        .subject("트위버 인증코드입니다.")
+        .text(text)
+        .build());
+  }
+
+  public String createCode() {
+    return RandomStringUtils.randomAlphanumeric(6);
+  }
+
+  public String createText(String code) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("인증코드를 입력해주세요.\n").append(code);
+    return sb.toString();
   }
 }

--- a/src/main/java/com/valuewith/tweaver/commons/redis/RedisUtilService.java
+++ b/src/main/java/com/valuewith/tweaver/commons/redis/RedisUtilService.java
@@ -1,0 +1,25 @@
+package com.valuewith.tweaver.commons.redis;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtilService {
+
+  private final StringRedisTemplate stringRedisTemplate;
+
+  public String getData(String key) {
+    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+    return valueOperations.get(key);
+  }
+
+  public void setDataTimeout(String key, String value, Long minutes) {
+    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+    Duration timeout = Duration.ofMinutes(minutes);
+    valueOperations.set(key, value, timeout);
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/config/AuthConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/AuthConfig.java
@@ -1,0 +1,14 @@
+package com.valuewith.tweaver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+
+  @Bean
+  public BCryptPasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/config/RedisConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.valuewith.tweaver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+}

--- a/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
+++ b/src/main/java/com/valuewith/tweaver/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.valuewith.tweaver.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  /**
+   * swagger, h2-console 접근을 위한 설정입니다.
+   * 인증이 필요한 URI 목록 중 아래에 있는 [허용 URL]의 모든 접근을 허용합니다.
+   * 사실상 모든 요청("/**")에 접근을 허용했습니다.
+   */
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf().disable().sessionManagement().
+        sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+        .authorizeHttpRequests().antMatchers(
+            // 허용 URL
+            "/v2/api-docs", "/v3/api-docs", "/v3/api-docs/**", "/swagger-resources",
+            "/swagger-resources/**", "/configuration/ui", "/configuration/security", "/swagger-ui/**",
+            "/webjars/**", "/swagger-ui.html", "/**", "/h2-console")
+        .permitAll().anyRequest().authenticated()
+        .and().headers().frameOptions().disable();
+    return http.build();
+  }
+
+}

--- a/src/main/java/com/valuewith/tweaver/user/repository/UserRepository.java
+++ b/src/main/java/com/valuewith/tweaver/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.valuewith.tweaver.user.repository;
+
+import com.valuewith.tweaver.user.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<Member, Long> {
+  Boolean existsByEmail(String email);
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원가입, 이메일로 인증코드 전송, 인증코드 검증 기능을 구현하였습니다.

**TO-BE**
- 회원가입을 성공적으로 완료하면 "회원가입 완료" 문자열을 리턴합니다.
- 인증번호는 Apache commons lang3를 사용하여 6자리 숫자+알파벳대소문자 형태로 구현했습니다.
- 인증번호는 Redis에 5분간 저장됩니다.
- 회원가입시 비밀번호 암호화를 위해 Spring-security를 의존성에 추가했습니다.


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
    - 테스트코드 작성중에 도저히 안될 것 같아 테스트코드는 작성하지 못했습니다.
- [x] API 테스트 
    - Swagger: API 테스트 완료했습니다. 
    - Postman: API 테스트 완료했습니다.
        - /signup, /verify, /verify/check 완료